### PR TITLE
Optimize project total recalculation

### DIFF
--- a/Y6_Update
+++ b/Y6_Update
@@ -20,6 +20,11 @@ const NUM_CELLS_TO_COLOR = 7; // Added for number of cells to color in addArchiv
 const NUM_COLUMNS_HIDE = 7; // Added for number of columns to hide/unhide in hideSelectedWeek and unhidePreviousWeek functions
 const MAX_ROWS_TO_PASTE = 4; // Added so onEdit doesnt run when pasting into Archive
 const COLUMN_OFFSET = 8; // Used in "update based on column 5"
+const STATUS_COLUMN = DROPDOWN_COLUMN; // Column D for task status
+const HOURS_COLUMN = 8; // Column H for hours entry
+const HEADER_COLOR_COLUMN = 1; // Column A used to identify project headers
+const HEADER_COLOR = '#d5a6bd'; // Background color for project headers
+const CACHE_EXPIRATION = 3600; // Cache lifetime in seconds
 
 function onOpen() {
   const ui = SpreadsheetApp.getUi(); // Get the user interface for the spreadsheet
@@ -157,6 +162,7 @@ function onEdit(e) {
     var numRows = range.getNumRows();
     var startColumn = range.getColumn();
     var numColumns = range.getNumColumns();
+    var rowsToUpdate = new Set();
 
     // Exit if the action is in the header (rows 1-9) or if more than 4 rows are being edited
     if (startRow <= HEADER_END_ROW || numRows > MAX_ROWS_TO_PASTE) {
@@ -184,8 +190,17 @@ function onEdit(e) {
         if (currentColumn >= START_COLUMN_PASTE_CHECK) {
           updateDropdownBasedOnValues(sheet, currentRow);
         }
+
+        // Track rows where status or hours changed
+        if (currentColumn === STATUS_COLUMN || currentColumn === HOURS_COLUMN) {
+          rowsToUpdate.add(currentRow);
+        }
       }
     }
+
+    rowsToUpdate.forEach(function (r) {
+      updateProjectTotal(sheet, r);
+    });
   }
 }
 
@@ -528,17 +543,77 @@ function groupSelectedRows() {
   Sheets.Spreadsheets.batchUpdate(request, SpreadsheetApp.getActiveSpreadsheet().getId());
 }
 
+function findProjectHeaderRow(sheet, row) {
+  for (var r = row; r > 0; r--) {
+    if ((sheet.getRange(r, HEADER_COLOR_COLUMN).getBackground() || '').toLowerCase() === HEADER_COLOR) {
+      return r;
+    }
+  }
+  return null;
+}
+
+function computeProjectSum(sheet, headerRow, useCache) {
+  if (useCache === undefined) useCache = true;
+  var cache = CacheService.getUserCache();
+  var key = sheet.getSheetId() + ':' + headerRow;
+  if (useCache) {
+    var cached = cache.get(key);
+    if (cached !== null) return parseFloat(cached);
+  }
+
+  var last = sheet.getLastRow();
+  var bgs = sheet.getRange(headerRow + 1, HEADER_COLOR_COLUMN, last - headerRow, 1).getBackgrounds();
+  var endExclusive = last + 1;
+  for (var i = 0; i < bgs.length; i++) {
+    if ((bgs[i][0] || '').toLowerCase() === HEADER_COLOR) {
+      endExclusive = headerRow + 1 + i;
+      break;
+    }
+  }
+
+  var rowCount = endExclusive - headerRow - 1;
+  if (rowCount <= 0) {
+    cache.put(key, '0', CACHE_EXPIRATION);
+    return 0;
+  }
+
+  var statusVals = sheet.getRange(headerRow + 1, STATUS_COLUMN, rowCount, 1).getValues();
+  var hourVals = sheet.getRange(headerRow + 1, HOURS_COLUMN, rowCount, 1).getValues();
+  var allowed = { scheduled: true, done: true };
+  var sum = 0;
+  for (var j = 0; j < rowCount; j++) {
+    var st = String(statusVals[j][0] || '').toLowerCase().trim();
+    if (allowed[st]) {
+      var h = parseFloat(hourVals[j][0]);
+      if (!isNaN(h)) sum += h;
+    }
+  }
+  sum = Math.round(sum * 100) / 100;
+  if (useCache) cache.put(key, String(sum), CACHE_EXPIRATION);
+  return sum;
+}
+
+function updateProjectTotal(sheet, row) {
+  var headerRow = findProjectHeaderRow(sheet, row);
+  if (!headerRow) return;
+  var cache = CacheService.getUserCache();
+  cache.remove(sheet.getSheetId() + ':' + headerRow);
+  var total = computeProjectSum(sheet, headerRow);
+  sheet.getRange(headerRow, HOURS_COLUMN).setValue(total);
+}
+
 /**
  * Sum hours under a colored project header until the next header of the same color.
  * Counts only rows whose Status is "scheduled" or "done" (case-insensitive).
  *
- * Use in the HEADER's G cell:
- *   =ProjectHoursAt(ROW(), COLUMN(), $D:$D, $H:$H, "#d5a6bd", "A")
+ * Use in the HEADER's hours cell:
+ *   =ProjectHoursAt(ROW(), COLUMN())
+ * Optional parameters allow overriding the header color or column letter.
  *
  * @param {number} headerRow           e.g., ROW()
  * @param {number} headerCol           e.g., COLUMN()
- * @param {Range}  statusColRange      full Status column (e.g., $D:$D)
- * @param {Range}  hoursColRange       full Hours column  (e.g., $H:$H)
+ * @param {Range}  statusColRange      (unused) retained for backward compatibility
+ * @param {Range}  hoursColRange       (unused) retained for backward compatibility
  * @param {string} [headerHex]         header color (default "#D5A6D5")
  * @param {string} [headerColorCol]    column letter to scan for headers (default "A")
  * @return {number} Rounded sum (2 dp). Returns 0 if not a header or on error.
@@ -546,53 +621,23 @@ function groupSelectedRows() {
  */
 function ProjectHoursAt(headerRow, headerCol, statusColRange, hoursColRange, headerHex, headerColorCol) {
   try {
-    const sh = SpreadsheetApp.getActiveSheet();
-    const last = sh.getLastRow();
+    var sh = SpreadsheetApp.getActiveSheet();
+    var last = sh.getLastRow();
     if (!headerRow || !headerCol || headerRow > last) return 0;
 
-    const targetHex = (headerHex || "#D5A6BD").toLowerCase();
-    const colorColLetter = (headerColorCol || "A").toUpperCase();
-
-    const letterToCol = (L) => {
-      let c = 0;
-      for (let i = 0; i < L.length; i++) c = c * 26 + (L.charCodeAt(i) - 64);
+    var targetHex = (headerHex || HEADER_COLOR).toLowerCase();
+    var letterToCol = function (L) {
+      var c = 0;
+      for (var i = 0; i < L.length; i++) c = c * 26 + (L.charCodeAt(i) - 64);
       return c;
     };
+    var colorCol = letterToCol((headerColorCol || 'A').toUpperCase());
+    if ((sh.getRange(headerRow, colorCol).getBackground() || '').toLowerCase() !== targetHex) return 0;
 
-    // Which column to use for header color detection?
-    const bgHere = (sh.getRange(headerRow, headerCol).getBackground() || "").toLowerCase();
-    let checkCol = bgHere === targetHex ? headerCol : letterToCol(colorColLetter);
-    if ((sh.getRange(headerRow, checkCol).getBackground() || "").toLowerCase() !== targetHex) return 0;
-
-    if (headerRow === last) return 0;
-
-    // Find the next header of the same color (stop before it)
-    const bgs = sh.getRange(headerRow + 1, checkCol, last - headerRow, 1).getBackgrounds();
-    let endExclusive = last + 1;
-    for (let i = 0; i < bgs.length; i++) {
-      if ((bgs[i][0] || "").toLowerCase() === targetHex) {
-        endExclusive = headerRow + 1 + i;
-        break;
-      }
-    }
-    if (endExclusive <= headerRow + 1) return 0;
-
-    // Flatten inputs (passing ranges makes the cell depend on them → auto-recalc)
-    const statuses = statusColRange.map(r => String(r[0] ?? "").toLowerCase().trim());
-    const hours = hoursColRange.map(r => r[0]);
-
-    const allowed = new Set(["scheduled", "done"]);
-    let sum = 0;
-    for (let r = headerRow + 1; r < endExclusive; r++) {
-      const st = statuses[r - 1];
-      if (allowed.has(st)) {
-        const h = parseFloat(hours[r - 1]);
-        if (!isNaN(h)) sum += h;
-      }
-    }
-    return Math.round(sum * 100) / 100; // ROUND(..., 2)
+    // Always recompute to reflect the latest edits; bypass cache
+    return computeProjectSum(sh, headerRow, false);
   } catch (err) {
-    return 0; // IFERROR(...,0)
+    return 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- Allow computeProjectSum to optionally bypass the cache
- Recalculate project totals on every ProjectHoursAt call to ensure fresh values
- Document new usage without full-column range dependencies

## Testing
- `node --check Y6_Update`


------
https://chatgpt.com/codex/tasks/task_e_689e4cd9f4188332b1c5dcc3c3f250ed